### PR TITLE
Bump sbt-docker.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Flyway" at "https://flywaydb.org/repo"
 
 addSbtPlugin("org.flywaydb" % "flyway-sbt" % "4.0")
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.3.0")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.4.1")
 addSbtPlugin("com.trueaccord.scalapb" % "sbt-scalapb" % "0.5.24")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 


### PR DESCRIPTION
`sbt docker`

I was getting following error until I had updated sbt-docker plugin:

```
[info] Successfully built efb5c2b709a2
[info] Tagging image efb5c2b709a2 with name: ihavemoney/write-frontend:latest
[info] unknown shorthand flag: 'f' in -f
[info] See 'docker tag --help'.
java.lang.RuntimeException: Nonzero exit code: 125
	at scala.sys.process.BasicIO$Streamed$.scala$sys$process$BasicIO$Streamed$$next$1(BasicIO.scala:48)
```
